### PR TITLE
use fromFileUrl

### DIFF
--- a/gen/dts.ts
+++ b/gen/dts.ts
@@ -1,4 +1,5 @@
 import { parse, Root, Type, Service, Field } from "../proto.ts";
+import { fromFileUrl } from "https://deno.land/std@0.110.0/path/mod.ts";
 
 type TypeOrEnum = Type & { values: Record<string, number> };
 
@@ -107,7 +108,7 @@ ${[...allOfKind<TypeOrEnum>(root, (s) => !!s.fields || !!s.values)]
 
 if (import.meta.main && Deno.args[0]) {
   const url = new URL(Deno.args[0], `file://${Deno.cwd()}/`);
-  const txt = await Deno.readTextFile(url.pathname);
+  const txt = await Deno.readTextFile(fromFileUrl(url.toString()));
 
   console.log(fromProto(txt));
 }


### PR DESCRIPTION
On Windows, pathname return a path beginning with slash. it should use fromFileUrl.

![image](https://user-images.githubusercontent.com/10111/175437299-3fdab15d-f1f1-46b0-a764-8de415f8ab65.png)
